### PR TITLE
Include xdebug in images

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -54,6 +54,9 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
+RUN pecl install xdebug-2.6.0
+RUN docker-php-ext-enable xdebug
+
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 COPY ./scripts ./scripts

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -54,6 +54,9 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
+RUN pecl install xdebug-2.6.0
+RUN docker-php-ext-enable xdebug
+
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 COPY ./scripts ./scripts

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -54,6 +54,9 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
+RUN pecl install xdebug-2.6.0
+RUN docker-php-ext-enable xdebug
+
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 COPY ./scripts ./scripts


### PR DESCRIPTION
Since these images are primarily (I think) used for testing environments I think it would be good to include xdebug by default.