### PR TITLE
Install default node version

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -5,6 +5,7 @@ ARG VCS_REF
 
 ENV COMPOSER_NO_INTERACTION=1
 ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV NVM_DIR=/root/.nvm
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/laratools/ci.git" \
@@ -58,6 +59,10 @@ RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+
+RUN . ~/.nvm/nvm.sh && \
+        nvm install lts/carbon && \
+        nvm alias default lts/carbon
 
 COPY ./scripts ./scripts
 

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -58,7 +58,8 @@ RUN docker-php-ext-install -j$(nproc) \
 RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+RUN mkdir -p $NVM_DIR && \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 RUN . ~/.nvm/nvm.sh && \
         nvm install lts/carbon && \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -5,6 +5,7 @@ ARG VCS_REF
 
 ENV COMPOSER_NO_INTERACTION=1
 ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV NVM_DIR=/root/.nvm
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/laratools/ci.git" \
@@ -58,6 +59,10 @@ RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+
+RUN . ~/.nvm/nvm.sh && \
+        nvm install lts/carbon && \
+        nvm alias default lts/carbon
 
 COPY ./scripts ./scripts
 

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -58,7 +58,8 @@ RUN docker-php-ext-install -j$(nproc) \
 RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+RUN mkdir -p $NVM_DIR && \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 RUN . ~/.nvm/nvm.sh && \
         nvm install lts/carbon && \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -5,6 +5,7 @@ ARG VCS_REF
 
 ENV COMPOSER_NO_INTERACTION=1
 ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV NVM_DIR=/root/.nvm
 
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url="https://github.com/laratools/ci.git" \
@@ -58,6 +59,10 @@ RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+
+RUN . ~/.nvm/nvm.sh && \
+        nvm install lts/carbon && \
+        nvm alias default lts/carbon
 
 COPY ./scripts ./scripts
 

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -58,7 +58,8 @@ RUN docker-php-ext-install -j$(nproc) \
 RUN pecl install xdebug-2.6.0
 RUN docker-php-ext-enable xdebug
 
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
+RUN mkdir -p $NVM_DIR && \
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash
 
 RUN . ~/.nvm/nvm.sh && \
         nvm install lts/carbon && \

--- a/goss.yaml
+++ b/goss.yaml
@@ -1,4 +1,12 @@
 command:
+  . ~/.nvm/nvm.sh && npm --version:
+    exit-status: 0
+  . ~/.nvm/nvm.sh && node --version:
+    exit-status: 0
+  . ~/.nvm/nvm.sh && nvm alias:
+    exit-status: 0
+    stdout:
+    - "/default \\-\\> lts\\/carbon/"
   . ~/.nvm/nvm.sh && nvm --version:
     exit-status: 0
     stderr: []


### PR DESCRIPTION
There's some weird behaviour with nvm which is stopping it from loading when an `.nvmrc` file is present.

It looks like nvm requires that a default alias exists and is installed in order for it to load correctly, even when passing `--install` and `--no-use` flags to the `nvm.sh` script.

This PR installs `lts/carbon` (version 8) node and aliases it to `default` which nvm seems to look for.