### PR TITLE
Yarn requires gnupg

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -21,7 +21,7 @@ ENV NVM_VERSION v0.33.9
 RUN apt-get update
 
 # Required to add yarn package repository
-RUN apt-get install -y apt-transport-https
+RUN apt-get install -y apt-transport-https gnupg
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -21,7 +21,7 @@ ENV NVM_VERSION v0.33.9
 RUN apt-get update
 
 # Required to add yarn package repository
-RUN apt-get install -y apt-transport-https
+RUN apt-get install -y apt-transport-https gnupg
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
Seems we don't have `gnupg` on `7.0` and `7.1` images which is breaking the build