### PR TITLE
Install ext-redis

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -48,7 +48,6 @@ RUN docker-php-ext-install -j$(nproc) \
         mcrypt \
         pcntl \
         pdo_mysql \
-        redis \
         shmop \
         sockets \
         sysvmsg \
@@ -56,8 +55,10 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
-RUN pecl install xdebug-2.6.0
-RUN docker-php-ext-enable xdebug
+RUN pecl install redis xdebug-2.6.0
+RUN docker-php-ext-enable \
+        redis \
+        xdebug
 
 RUN mkdir -p $NVM_DIR && \
     curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -48,6 +48,7 @@ RUN docker-php-ext-install -j$(nproc) \
         mcrypt \
         pcntl \
         pdo_mysql \
+        redis \
         shmop \
         sockets \
         sysvmsg \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -48,7 +48,6 @@ RUN docker-php-ext-install -j$(nproc) \
         mcrypt \
         pcntl \
         pdo_mysql \
-        redis \
         shmop \
         sockets \
         sysvmsg \
@@ -56,8 +55,10 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
-RUN pecl install xdebug-2.6.0
-RUN docker-php-ext-enable xdebug
+RUN pecl install redis xdebug-2.6.0
+RUN docker-php-ext-enable \
+        redis \
+        xdebug
 
 RUN mkdir -p $NVM_DIR && \
     curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -48,6 +48,7 @@ RUN docker-php-ext-install -j$(nproc) \
         mcrypt \
         pcntl \
         pdo_mysql \
+        redis \
         shmop \
         sockets \
         sysvmsg \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -48,7 +48,6 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
-        redis \
         shmop \
         sockets \
         sysvmsg \
@@ -56,8 +55,10 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
-RUN pecl install xdebug-2.6.0
-RUN docker-php-ext-enable xdebug
+RUN pecl install redis xdebug-2.6.0
+RUN docker-php-ext-enable \
+        redis \
+        xdebug
 
 RUN mkdir -p $NVM_DIR && \
     curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -48,6 +48,7 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
+        redis \
         shmop \
         sockets \
         sysvmsg \

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -49,7 +49,6 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
-        redis \
         shmop \
         sockets \
         sysvmsg \
@@ -57,8 +56,10 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
-RUN pecl install xdebug-2.7.0
-RUN docker-php-ext-enable xdebug
+RUN pecl install redis xdebug-2.7.0
+RUN docker-php-ext-enable \
+        redis \
+        xdebug
 
 RUN mkdir -p $NVM_DIR && \
     curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -49,6 +49,7 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
+        redis \
         shmop \
         sockets \
         sysvmsg \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -50,7 +50,6 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
-        redis \
         shmop \
         sockets \
         sysvmsg \
@@ -58,8 +57,10 @@ RUN docker-php-ext-install -j$(nproc) \
         sysvshm \
         zip
 
-RUN pecl install xdebug-2.8.0beta2
-RUN docker-php-ext-enable xdebug
+RUN pecl install redis xdebug-2.8.0beta2
+RUN docker-php-ext-enable \
+        redis \
+        xdebug
 
 RUN mkdir -p $NVM_DIR && \
     curl -o- https://raw.githubusercontent.com/creationix/nvm/${NVM_VERSION}/install.sh | bash

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -50,6 +50,7 @@ RUN docker-php-ext-install -j$(nproc) \
         sodium \
         pcntl \
         pdo_mysql \
+        redis \
         shmop \
         sockets \
         sysvmsg \


### PR DESCRIPTION
Install `ext-redis` as it's now the recommended option because `predis/predis` is now abandoned.